### PR TITLE
fix(demo): auto-install demo deps in root dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "start": "tsup --watch",
-    "dev": "npm --prefix demo run dev",
+    "dev": "npm --prefix demo install && npm --prefix demo run dev",
     "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

Fixes #8 — a fresh clone fails to start the demo with the root `dev` script.

The root `dev` script delegated to the demo's vite (`npm --prefix demo run dev`) without ensuring the demo's dependencies were installed. Because the root and `demo/` are **separate npm projects** (no workspaces; `demo/` has its own `package.json` + lockfile), a root `npm install` never installs `@vitejs/plugin-react` — which `demo/vite.config.ts` imports at config-load time.

Result on a fresh clone:

```
npm install
npm run dev
# → Cannot find package '@vitejs/plugin-react'
```

## Fix

Prepend an idempotent install to the root `dev` script:

```diff
- "dev": "npm --prefix demo run dev",
+ "dev": "npm --prefix demo install && npm --prefix demo run dev",
```

- Idempotent — npm no-ops when demo deps already match the lockfile, so repeat runs stay fast.
- Mirrors the existing `netlify-build` script, which already runs `cd demo && npm install` before building.

The README and CONTRIBUTING docs already document `cd demo && npm install && npm run dev`, so this change closes the gap for the root-level `dev` script specifically.

## Test plan

- [ ] Fresh clone → `npm install` (root) → `npm run dev` starts the demo without a separate `cd demo && npm install`.