### PR TITLE
fix: contain exceptions thrown by consumer onError callback

### DIFF
--- a/src/ImageEditor.tsx
+++ b/src/ImageEditor.tsx
@@ -47,7 +47,17 @@ function ImageEditorInner(
     const err = error instanceof Error ? error : new Error(String(error));
     const { onError } = latestPropsRef.current;
     if (onError) {
-      onError(err);
+      // A throwing onError must never escape: fail() runs as the terminal
+      // .catch of the serialized chain, so a throw here would reject
+      // chainRef and poison every subsequent link (see the invariant above).
+      try {
+        onError(err);
+      } catch (callbackError) {
+        console.error(
+          '[react-image-editor] onError callback threw',
+          callbackError
+        );
+      }
     } else {
       console.error('[react-image-editor]', err);
     }

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -477,6 +477,35 @@ it('reports a reset rejection via onError without poisoning the chain', async ()
   expect(mockInstance.reset).toHaveBeenLastCalledWith('img-c');
 });
 
+it('contains a throwing onError without poisoning the chain', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const onError = vi.fn(() => {
+    throw new Error('boom');
+  });
+  const { rerender } = render(<ImageEditor image="img-a" onError={onError} />);
+  await flush();
+
+  // fail() runs as the terminal .catch of the chain; a throwing onError
+  // must be swallowed rather than rejecting chainRef.
+  mockInstance.reset.mockRejectedValueOnce(new Error('reload failed'));
+  rerender(<ImageEditor image="img-b" onError={onError} />);
+  await flush();
+
+  expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  // The callback's own throw is reported, not propagated.
+  expect(consoleError).toHaveBeenCalledWith(
+    '[react-image-editor] onError callback threw',
+    expect.any(Error)
+  );
+
+  // The chain survived: a later image change still resets normally.
+  rerender(<ImageEditor image="img-c" onError={onError} />);
+  await flush();
+  expect(mockInstance.reset).toHaveBeenLastCalledWith('img-c');
+
+  consoleError.mockRestore();
+});
+
 it('waits for a pending reset before destroying on unmount', async () => {
   const resetDeferred = defer<void>();
   mockInstance.reset.mockImplementationOnce(() => resetDeferred.promise);


### PR DESCRIPTION
## Summary

Fixes #9 — a consumer `onError` callback that throws escapes the wrapper as an unhandled promise rejection.

`fail()` invokes the consumer's `onError` unguarded. Since `fail` is used as the terminal `.catch` handler of the serialized mount/reset chain, a throw inside `onError` rejects `chainRef.current` with no downstream handler → **unhandled promise rejection**.

It also has a consequence the original report didn't note: it **poisons the serialized chain**, violating the invariant the code documents (`// Every link ends in .catch so a rejection never poisons it.`). Once `chainRef` is left rejected, subsequent mount/reset `.then` links are silently skipped — later image changes are dropped and the consumer may be re-notified with a stale error.

## Fix

Wrap the `onError` call in `try/catch` and route a callback exception to `console.error`, so the diagnostic path can never become a new failure. The original error still reaches the consumer; callback exceptions can't escape.

## Severity note

This only triggers when the consumer's own `onError` throws (a misbehaving void callback), so it does not affect well-behaved callers. The fix is included because it is nearly free and makes the code's documented no-poison invariant actually hold.

## Test plan

- [x] `npm test` — 41 passing, including a new regression test (`'contains a throwing onError without poisoning the chain'`) that asserts the throw is swallowed and the chain still resets afterward. Verified the test fails (unhandled rejection) with the guard removed.