### PR TITLE
chore(release): 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unlayer/react-image-editor",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unlayer/react-image-editor",
-      "version": "1.0.0-beta.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@unlayer/types": "1.448.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlayer/react-image-editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Unlayer's Image Editor Component for React.js",
   "type": "commonjs",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release 1.0.1

Patch release bundling the two merged bug fixes:

- **#8** — `fix(demo)`: root `dev` script now auto-installs demo deps (PR #12)
- **#9** — `fix`: consumer `onError` exceptions are contained instead of escaping as unhandled rejections (PR #13)

No API changes → semver patch.

### Pre-publish verification (run locally against this branch)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 41 passing
- [x] `npm run build` — dist emitted (CJS + ESM + d.ts)
- [x] `npm pack --dry-run` — packs as `@unlayer/react-image-editor@1.0.1` (9 files, 15.4 kB)

### Publish
Merge this, then publish from an npm-authenticated environment:
```sh
git checkout main && git pull
npm run release   # runs build + npm publish (prepublishOnly gates on lint+typecheck+test)
```