### PR TITLE
fix: contain exceptions thrown by consumer `onLoad` callback

### DIFF
--- a/src/ImageEditor.tsx
+++ b/src/ImageEditor.tsx
@@ -117,7 +117,17 @@ function ImageEditorInner(
           mountOptions.translations,
         ]);
         setEditor(created);
-        latestPropsRef.current.onLoad?.(created);
+        // The editor mounted successfully, so a throw from the consumer's
+        // callback must not reach the terminal .catch below, where it would
+        // surface as a wrapper failure and could hard-reset the loader.
+        try {
+          latestPropsRef.current.onLoad?.(created);
+        } catch (callbackError) {
+          console.error(
+            '[react-image-editor] onLoad callback threw',
+            callbackError
+          );
+        }
       })
       .catch((error) => {
         // If the versioned bundle never evaluated, the CDN loader has

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -506,6 +506,36 @@ it('contains a throwing onError without poisoning the chain', async () => {
   consoleError.mockRestore();
 });
 
+it('contains a throwing onLoad without reporting a wrapper failure', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const onError = vi.fn();
+  const onLoad = vi.fn(() => {
+    throw new Error('boom');
+  });
+
+  const { rerender } = render(
+    <ImageEditor image="img-a" onLoad={onLoad} onError={onError} />
+  );
+  await flush();
+
+  // The callback's own throw is reported, not propagated.
+  expect(consoleError).toHaveBeenCalledWith(
+    '[react-image-editor] onLoad callback threw',
+    expect.any(Error)
+  );
+  // The editor mounted, so the consumer must not see a wrapper failure and
+  // the shared loader must survive.
+  expect(onError).not.toHaveBeenCalled();
+  expect(resetLoader).not.toHaveBeenCalled();
+
+  // The instance is still live: a later image change resets normally.
+  rerender(<ImageEditor image="img-b" onLoad={onLoad} onError={onError} />);
+  await flush();
+  expect(mockInstance.reset).toHaveBeenLastCalledWith('img-b');
+
+  consoleError.mockRestore();
+});
+
 it('waits for a pending reset before destroying on unmount', async () => {
   const resetDeferred = defer<void>();
   mockInstance.reset.mockImplementationOnce(() => resetDeferred.promise);


### PR DESCRIPTION
## Summary

A throw from `onLoad` was reported as a wrapper failure even though the editor had already mounted.

**Reproduction:**

```jsx
<ImageEditor
  image={url}
  onLoad={() => {
    setStatus('Editor ready');
    throw new Error('boom');
  }}
  onError={(error) => setStatus(`Error: ${error.message}`)}
/>
```

<img width="1279" height="692" alt="Screenshot 2026-08-28 at 11 31 55" src="https://github.com/user-attachments/assets/7b084903-6ecf-463f-8e5c-c54b772e97db" />

## Fix

Wrap the `onLoad` call in `try/catch` and log the callback exception with `console.error`, the same way `fail()` already contains a throwing `onError`.

<img width="1275" height="671" alt="Screenshot 2026-08-28 at 11 25 23" src="https://github.com/user-attachments/assets/400d8b67-69ea-427d-8841-98e076f01b0a" />

## Note

This only happens when the consumer's own `onLoad` throws. Well-behaved callers are unaffected. The guard is cheap and keeps `onError` reserved for real wrapper failures.