### PR TITLE
Support image editor dock and rounded-corners options in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ All tools are enabled by default. Configure them through `options.features.image
   options={{
     features: {
       imageEditor: {
+        dock: 'left',
         tools: {
+          corners: false,
           draw: false,
           stickers: false,
           frame: { enabled: false }, // object form, same effect
@@ -170,7 +172,7 @@ All tools are enabled by default. Configure them through `options.features.image
 Two things to keep in mind:
 
 - `features` is a remount-tier option (see the table above): changing the tools config destroys and recreates the editor, discarding unsaved edits — decide the toolset before mounting rather than toggling it live.
-- `features.imageEditor: false` disables the editing UI entirely; newer editor versions also support `features.imageEditor.dock: 'left' | 'right'` for the rail position and a `corners` entry (the rounded-corners control inside Crop) — these type-check once your `@unlayer/types` version includes them.
+- `features.imageEditor: false` disables the editing UI entirely. Use `features.imageEditor.dock: 'left' | 'right'` to position the tool rail; the rounded-corners control inside Crop is configured through `features.imageEditor.tools.corners`.
 
 ## AI Assistant
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@unlayer/types": "1.448.0"
+        "@unlayer/types": "1.477.0"
       },
       "devDependencies": {
         "@testing-library/react": "16.3.2",
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/@unlayer/types": {
-      "version": "1.448.0",
-      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.448.0.tgz",
-      "integrity": "sha512-k7NhJEdp5d40pWRAp9hSpTsyjD/vCrWrinNJaZkkXRU4YK7nsa9EYvnXHmVa/TcuevmPz0JRxzi8rJ1qSfvFDw==",
+      "version": "1.477.0",
+      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.477.0.tgz",
+      "integrity": "sha512-yTadBVaN7IjBEo8S9CELJvFTxS960x6KHRsPsgW+nBQwPMAaKnCL8Eg4RV/dYdQ6pd2IOUxNjKjVIjTIEMXJzQ==",
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": ">=18"
   },
   "dependencies": {
-    "@unlayer/types": "1.448.0"
+    "@unlayer/types": "1.477.0"
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -3,6 +3,7 @@ import { act, render } from '@testing-library/react';
 
 import ImageEditor, {
   ImageEditorInstance,
+  ImageEditorOptions,
   ImageEditorRef,
   ImageEditorSaveResult,
   MountOptions,
@@ -103,7 +104,9 @@ it('passes every documented option through to createEditor unchanged', async () 
     features: {
       imageEditor: {
         enabled: true,
+        dock: 'left',
         tools: {
+          corners: true,
           draw: false,
           stickers: { enabled: false },
           crop: { icon: 'fa-crop-simple' },
@@ -113,15 +116,15 @@ it('passes every documented option through to createEditor unchanged', async () 
       ai: { enabled: true, assistant: true },
     },
     env: { API_V2_BASE_URL: 'https://api.example.com' },
-    theme: 'dark' as const,
-    locale: 'es' as const,
+    theme: 'dark',
+    locale: 'es',
     translations: { es: { 'editor.save': 'Guardar' } },
     offline: false,
     licenseUrl: 'https://example.com/license.json',
     defaultPrompt: 'Remove the background',
     autoSubmitPrompt: false,
-    aiAssistantOpenState: 'closed' as const,
-  };
+    aiAssistantOpenState: 'closed',
+  } satisfies ImageEditorOptions;
 
   render(<ImageEditor image="img-a" options={options} />);
   await flush();


### PR DESCRIPTION
## Summary

Fixes TypeScript errors when configuring the supported image editor `dock` and `corners` options.

## Changes

- Upgrade `@unlayer/types` from `1.448.0` to `1.477.0`
- Support `features.imageEditor.dock: 'left' | 'right'`
- Support `features.imageEditor.tools.corners`
- Add type-level regression coverage using `satisfies ImageEditorOptions`
- Update the README with the correct option nesting