### PR TITLE
feat(demo): add a dock control for the editor tool rail

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -28,6 +28,7 @@ export default function App() {
   const [image, setImage] = useState(SAMPLE_IMAGES[0]);
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [locale, setLocale] = useState<UnlayerLocale>('en');
+  const [dock, setDock] = useState<'left' | 'right'>('right');
   const [tools, setTools] =
     useState<Record<ToolName, boolean>>(allToolsEnabled);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -88,6 +89,11 @@ export default function App() {
     }
   };
 
+  const changeDock = (next: 'left' | 'right') => {
+    setDock(next);
+    setStatus(`Dock "${next}" (remount)`);
+  };
+
   const toggleTool = (tool: ToolName) => {
     setTools((previous) => ({ ...previous, [tool]: !previous[tool] }));
     setStatus(`Tool "${tool}" toggled (remount)`);
@@ -115,6 +121,8 @@ export default function App() {
             onThemeChange={setTheme}
             locale={locale}
             onLocaleChange={setLocale}
+            dock={dock}
+            onDockChange={changeDock}
             tools={tools}
             onToolToggle={toggleTool}
             onChangeImage={nextImage}
@@ -131,7 +139,7 @@ export default function App() {
             options={{
               theme,
               locale,
-              features: { imageEditor: { tools } },
+              features: { imageEditor: { dock, tools } },
             }}
             onLoad={() => setStatus('Editor ready')}
             onSave={(result) => {

--- a/demo/src/Sidebar.tsx
+++ b/demo/src/Sidebar.tsx
@@ -28,6 +28,8 @@ interface SidebarProps {
   onThemeChange(theme: 'light' | 'dark'): void;
   locale: UnlayerLocale;
   onLocaleChange(locale: UnlayerLocale): void;
+  dock: 'left' | 'right';
+  onDockChange(dock: 'left' | 'right'): void;
   tools: Record<ToolName, boolean>;
   onToolToggle(tool: ToolName): void;
   onChangeImage(): void;
@@ -91,6 +93,22 @@ export default function Sidebar(props: SidebarProps) {
                 {locale.label}
               </option>
             ))}
+          </select>
+        </label>
+      </section>
+
+      <section className="section">
+        <h2 className="section-label">Dock (remounts editor)</h2>
+        <label className="field">
+          Tool rail
+          <select
+            value={props.dock}
+            onChange={(event) =>
+              props.onDockChange(event.target.value as 'left' | 'right')
+            }
+          >
+            <option value="left">Left</option>
+            <option value="right">Right</option>
           </select>
         </label>
       </section>

--- a/demo/src/Sidebar.tsx
+++ b/demo/src/Sidebar.tsx
@@ -100,7 +100,7 @@ export default function Sidebar(props: SidebarProps) {
       <section className="section">
         <h2 className="section-label">Dock (remounts editor)</h2>
         <label className="field">
-          Tool rail
+          Toolbar position
           <select
             value={props.dock}
             onChange={(event) =>


### PR DESCRIPTION
## Summary

- Add a Left/Right dock control in the demo so you can move the editor tool rail
- Dock is a remount option (same as tools), not a live update like theme or locale

**Changes:**

<img width="3014" height="1718" alt="Screenshot 2026-09-02 at 11 05 16" src="https://github.com/user-attachments/assets/80910eb9-6e68-4c4b-ad76-e95ee332c97c" />

<img width="3016" height="1714" alt="image" src="https://github.com/user-attachments/assets/5e54a6f3-41c4-43f0-9484-35108a0630ef" />

