### PR TITLE
ci: add permissions, a concurrency group, and pin actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,24 @@ on:
     branches: [main]
   pull_request:
 
+# These jobs only read the repository; the Codecov upload authenticates with
+# its own token rather than the workflow token.
+permissions:
+  contents: read
+
+# Superseded runs on a PR are pointless — the 6-job matrix keeps runners busy
+# for a result nobody will look at. Pushes to main still run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   checks:
     name: Lint, typecheck & build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -20,7 +31,7 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm run test:coverage
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -35,8 +46,8 @@ jobs:
         node: [20, 22, 24]
         react: [18, 19]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,15 @@ permissions:
   contents: read
 
 # Superseded runs on a PR are pointless — the 6-job matrix keeps runners busy
-# for a result nobody will look at. Pushes to main still run to completion.
+# for a result nobody will look at.
+#
+# PRs share a group keyed on the ref, so a new push supersedes the run it
+# replaces. Every other event — notably a push to main — gets a group of its
+# own keyed on run_id, because only one run per group may sit pending: with a
+# shared group, a third push would discard the second one's queued run even
+# though cancel-in-progress is off for pushes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Fixes #33.

Three standard hardening/efficiency settings, no behavioural change to what CI actually runs.

### `permissions: contents: read`

Neither job declared permissions, so both ran with the repository-wide default `GITHUB_TOKEN` scopes. They only need to read the repo — the Codecov step authenticates with `secrets.CODECOV_TOKEN`, not the workflow token.

### `concurrency` group

Pushing twice in quick succession to a PR left the superseded run occupying runners for the full 6-job matrix. Guarded on `github.event_name == 'pull_request'` so pushes to `main` still run to completion rather than cancelling each other.

### SHA-pinned actions

`actions/checkout`, `actions/setup-node` and `codecov/codecov-action` were on floating major tags.

**These pins are the exact commits `v4` / `v4` / `v5` resolve to right now**, so nothing about what executes changes — this is purely removing the mutable indirection:

| Action | SHA | Tag |
| --- | --- | --- |
| `actions/checkout` | `11d5960` | v4.4.0 |
| `actions/setup-node` | `49933ea` | v4.4.0 |
| `codecov/codecov-action` | `0fb7174` | v5.5.5 |

I deliberately did **not** bump the majors (v7/v7/v7 are current) — that is a separate change, and `.github/dependabot.yml` already watches the `github-actions` ecosystem, so Dependabot will open those PRs and keep the SHAs current from here on.
