### PR TITLE
ci: typecheck and build the demo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+  - package-ecosystem: npm
+    directory: /demo
+    schedule:
+      interval: weekly
+    groups:
+      demo-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,22 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+  demo:
+    name: Demo typecheck & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      # The demo aliases the package to ../src, so the root install has to
+      # exist for its dependencies to resolve.
+      - run: npm ci
+      - run: npm --prefix demo ci
+      - run: npm --prefix demo run typecheck
+      - run: npm --prefix demo run build
+
   test:
     name: Test (Node ${{ matrix.node }}, React ${{ matrix.react }})
     runs-on: ubuntu-latest

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "typecheck": "tsc --noEmit",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
Fixes #34.

## Problem

CI never touched `demo/`. Both jobs ran only at the repo root, so nothing installed, typechecked or built the demo — even though it:

- is aliased **straight to `../src`** (`demo/vite.config.ts`), making it the project's only integration harness for the component's public surface
- is the live demo linked from the README, so a break there is user-facing

It was already drifting: `demo/package.json` pins `@unlayer/types@1.448.0` while the root pins `1.477.0`, and nothing noticed.

## Change

1. A `demo` job that installs both workspaces and runs typecheck + build. The root `npm ci` is needed first because the alias resolves into the parent.
2. A `typecheck` script in `demo/package.json` — it had none, so there was nothing for CI to call.
3. A `/demo` entry in `.github/dependabot.yml`, grouped, so the demo's dependencies stop drifting behind the root.

## Verification

Ran the exact job steps locally against this tree:

```
demo typecheck OK
demo build OK
```

## Two notes for the reviewer

- **I left the `@unlayer/types` bump out of this PR** to keep it CI-scoped. I did verify separately that `1.477.0` typechecks *and* builds clean in the demo, so the Dependabot PR this change enables should be safe to merge.
- This touches `.github/workflows/ci.yml`, so it will conflict with #50 (SHA-pinning). The hunks are far apart and should merge cleanly, but whichever lands second will want the new `demo` job's `uses:` lines pinned to match. Happy to rebase whichever order you prefer.
