### PR TITLE
chore: require Node >= 20

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-[Node.js](https://nodejs.org/) >= v18 must be installed.
+[Node.js](https://nodejs.org/) >= v20 must be installed. CI tests on Node 20, 22 and 24.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #46.

`package.json` claimed `"engines": { "node": ">=18" }` and CONTRIBUTING.md repeated it, but the CI matrix is `[20, 22, 24]` — **Node 18 was claimed as supported and never exercised**. It also reached end-of-life in April 2025.

Of the two resolutions in the issue, this takes the first: drop the claim rather than add an EOL runtime to the matrix. That aligns all three statements — `engines`, CONTRIBUTING.md, and the CI matrix — on the range that is actually tested.

npm only *warns* on an `engines` mismatch by default, so this doesn't hard-break anyone still on 18; it corrects a signal that was wrong.

Happy to flip it to "add 18 to the matrix" instead if you'd rather keep supporting it — just say and I'll swap the PR.
