### PR TITLE
chore: gitignore lockfiles from other package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ node_modules
 .history
 dist
 /coverage
+
+# npm is the supported package manager (CI runs `npm ci` and the
+# package-lock.json files are committed). Keep a stray lockfile from another
+# resolver out of commits — two lockfiles in the tree make `npm ci` fail in
+# confusing ways for the next person.
+bun.lock
+bun.lockb
+pnpm-lock.yaml
+yarn.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 
 ## Installation
 
+- npm is the supported package manager. CI runs `npm ci`, and both `package-lock.json` files are committed — other resolvers are gitignored so a stray lockfile cannot be committed by accident.
 - Running `npm install` in the component's root directory will install everything you need for development.
 - Running `npm install` in the `demo` directory will install everything you need to run the demo app locally.
 


### PR DESCRIPTION
Fixes #45.

npm is clearly the intended package manager — both `package-lock.json` files are committed, CI runs `npm ci`, and CONTRIBUTING documents `npm install` throughout. But `.gitignore` didn't mention any other lockfile.

I hit this on a fresh clone: running `bun install` left `bun.lock` and `demo/bun.lock` untracked **and** rewrote `demo/package-lock.json` in place, with nothing in the repo signalling that was wrong. One `git add .` and the repo has two lockfiles — the state that makes `npm ci` fail confusingly for whoever clones next.

## Change

- Ignore `bun.lock`, `bun.lockb`, `pnpm-lock.yaml`, `yarn.lock`.
- State in CONTRIBUTING that npm is the supported package manager and why.

## Verification

```
$ touch bun.lock demo/bun.lock
$ git status --porcelain --untracked-files=all | grep -c bun.lock
0
```

## Deliberately not included

The issue also floated a `packageManager` field (Corepack) or an `engines.npm` constraint to make the wrong tool fail *loudly* rather than quietly. That's a stronger guarantee but a bigger behavioural change for contributors, so I left it as a separate call for you — happy to add it if you want it.
