### PR TITLE
fix: make the container styleable and give it an accessible name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,20 @@ The component works out of the box in React Server Components environments (e.g.
 
 ## Props
 
-| Prop          | Type                          | Description                                                                                                                                                                            |
-| ------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image`       | `string` (required)           | Image URL or base64 data URL to edit.                                                                                                                                                  |
-| `options`     | `ImageEditorOptions`          | Editor configuration: `projectId`, `user`, `features`, `theme`, `locale`, `translations`, `env`, `offline`, `licenseUrl`, `defaultPrompt`, `autoSubmitPrompt`, `aiAssistantOpenState`. |
-| `editorId`    | `string`                      | id for the container div. Cosmetic — the editor mounts by element reference.                                                                                                           |
-| `minHeight`   | `number \| string`            | Minimum height of the editor container. Defaults to `500`.                                                                                                                             |
-| `style`       | `CSSProperties`               | Styles applied to the container div.                                                                                                                                                   |
-| `onLoad`      | `(editor) => void`            | Called with the editor instance once it is mounted.                                                                                                                                    |
-| `onSave`      | `({ dataUrl, blob }) => void` | Called when the user saves the edited image.                                                                                                                                           |
-| `onCancel`    | `() => void`                  | Called when the user cancels editing.                                                                                                                                                  |
-| `onLoadError` | `() => void`                  | Called when the image fails to load into the canvas (CORS, 404, decode error).                                                                                                         |
-| `onError`     | `(error: Error) => void`      | Wrapper-level failures: embed script load, editor creation, or image reset. Falls back to `console.error` when absent.                                                                 |
+| Prop           | Type                          | Description                                                                                                                                                                            |
+| -------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`        | `string` (required)           | Image URL or base64 data URL to edit.                                                                                                                                                  |
+| `options`      | `ImageEditorOptions`          | Editor configuration: `projectId`, `user`, `features`, `theme`, `locale`, `translations`, `env`, `offline`, `licenseUrl`, `defaultPrompt`, `autoSubmitPrompt`, `aiAssistantOpenState`. |
+| `editorId`     | `string`                      | id for the container div. Cosmetic — the editor mounts by element reference.                                                                                                           |
+| `minHeight`    | `number \| string`            | Minimum height of the editor container. Defaults to `500`.                                                                                                                             |
+| `style`        | `CSSProperties`               | Styles applied to the container div. Overrides the default `flex: 1`.                                                                                                                  |
+| `wrapperStyle` | `CSSProperties`               | Styles applied to the outer wrapper div, which owns `minHeight` and the flex layout. Set this to drop the editor into a non-flex layout.                                               |
+| `ariaLabel`    | `string`                      | Accessible name for the editor region. Defaults to `'Image editor'`.                                                                                                                   |
+| `onLoad`       | `(editor) => void`            | Called with the editor instance once it is mounted.                                                                                                                                    |
+| `onSave`       | `({ dataUrl, blob }) => void` | Called when the user saves the edited image.                                                                                                                                           |
+| `onCancel`     | `() => void`                  | Called when the user cancels editing.                                                                                                                                                  |
+| `onLoadError`  | `() => void`                  | Called when the image fails to load into the canvas (CORS, 404, decode error).                                                                                                         |
+| `onError`      | `(error: Error) => void`      | Wrapper-level failures: embed script load, editor creation, or image reset. Falls back to `console.error` when absent.                                                                 |
 
 ## Editor instance (ref)
 

--- a/src/ImageEditor.tsx
+++ b/src/ImageEditor.tsx
@@ -13,7 +13,15 @@ function ImageEditorInner(
   props: ImageEditorProps,
   ref: React.Ref<ImageEditorRef>
 ) {
-  const { image, options = {}, scriptUrl, minHeight = 500, style = {} } = props;
+  const {
+    image,
+    options = {},
+    scriptUrl,
+    minHeight = 500,
+    style = {},
+    wrapperStyle = {},
+    ariaLabel = 'Image editor',
+  } = props;
 
   const [editor, setEditor] = useState<ImageEditorInstance | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -196,9 +204,20 @@ function ImageEditorInner(
         flex: 1,
         display: 'flex',
         minHeight: minHeight,
+        ...wrapperStyle,
       }}
     >
-      <div id={editorId} ref={containerRef} style={{ ...style, flex: 1 }} />
+      <div
+        id={editorId}
+        ref={containerRef}
+        // The embed renders an unlabelled generic div inside, so without a
+        // role and a name the whole editing surface is anonymous to
+        // assistive tech.
+        role="region"
+        aria-label={ariaLabel}
+        // flex first: a default the consumer's style can override.
+        style={{ flex: 1, ...style }}
+      />
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,8 +101,18 @@ export interface ImageEditorProps {
   editorId?: string;
   /** Minimum height of the editor container. Defaults to 500. */
   minHeight?: number | string;
-  /** Styles applied to the container div. */
+  /** Styles applied to the container div. Overrides the default `flex: 1`. */
   style?: CSSProperties;
+  /**
+   * Styles applied to the outer wrapper div, which owns `minHeight` and the
+   * flex layout. Set this to drop the editor into a non-flex layout.
+   */
+  wrapperStyle?: CSSProperties;
+  /**
+   * Accessible name for the editor region. The embed renders no landmark
+   * and no name of its own. Defaults to 'Image editor'.
+   */
+  ariaLabel?: string;
   /**
    * Override the embed script URL (e.g. to pin an environment). One embed
    * per page: the first loader to run installs window.ImageEditor and wins

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -361,6 +361,45 @@ it('applies minHeight and style to the container', async () => {
   );
 });
 
+it('lets style override the container default and wrapperStyle reach the wrapper', async () => {
+  render(
+    <ImageEditor
+      editorId="styled"
+      image="img-a"
+      minHeight={300}
+      style={{ flex: 'none', width: 640 }}
+      wrapperStyle={{ display: 'block', minHeight: 0 }}
+    />
+  );
+  await flush();
+
+  const container = document.querySelector('#styled') as HTMLElement;
+  const wrapper = container.parentElement as HTMLElement;
+
+  // flex is a default now, not a hardcoded override. ('none' is stored in
+  // expanded longhand form; the default `flex: 1` would be '1 1 0%'.)
+  expect(container.style.flex).toBe('0 0 auto');
+  expect(container.style.width).toBe('640px');
+  // The outer wrapper is reachable, so the component can be dropped into a
+  // non-flex layout.
+  expect(wrapper.style.display).toBe('block');
+  expect(wrapper.style.minHeight).toBe('0px');
+});
+
+it('gives the editor region an accessible name, overridable via ariaLabel', async () => {
+  const { rerender } = render(<ImageEditor editorId="a11y" image="img-a" />);
+  await flush();
+
+  const container = document.querySelector('#a11y') as HTMLElement;
+  expect(container.getAttribute('role')).toBe('region');
+  expect(container.getAttribute('aria-label')).toBe('Image editor');
+
+  rerender(
+    <ImageEditor editorId="a11y" image="img-a" ariaLabel="Avatar cropper" />
+  );
+  expect(container.getAttribute('aria-label')).toBe('Avatar cropper');
+});
+
 it('passes onCancel and onLoadError through to the editor', async () => {
   const onCancel = vi.fn();
   const onLoadError = vi.fn();


### PR DESCRIPTION
Fixes #43. Three problems in the same two divs.

### 1. `style` could not override `flex` (the actual bug)

```jsx
<div id={editorId} ref={containerRef} style={{ ...style, flex: 1 }} />
```

`flex: 1` was written **after** the spread, so it always won — `style={{ flex: 'none' }}` or `{ flex: '0 0 600px' }` was silently discarded. Moving it before the spread makes it a default the consumer can override, with zero effect on anyone who doesn't set it.

### 2. The outer wrapper was unreachable

`minHeight` was the only thing a consumer could influence on the outer div; its `flex: 1` and `display: flex` were fixed. Dropping the component into a plain block container, a grid cell or a fixed-height panel needed an extra wrapper plus `!important`. New `wrapperStyle` prop.

### 3. No accessible name

I checked what the embed actually renders inside the container on the running demo:

```json
{ "tag": "DIV", "cls": "image-editor-root", "role": null, "aria-label": null }
```

No landmark, no name, no headings — only `svg[role=img]` icons. So the entire editing surface was anonymous to assistive tech, and our container contributed nothing but an `id`.

Added `role="region"` with an `ariaLabel` prop defaulting to `'Image editor'`.

**This one is default-on, so flag it if you'd rather it weren't.** A labelled `region` is a landmark and will show up in screen-reader landmark lists for existing consumers. I went default-on because the measurement above shows there is otherwise *no* accessible name at all, and `region` is the conservative choice — `role="application"` would have changed screen-reader interaction mode, which I did not want to impose on a third-party UI.

## Verification

- 2 new tests; 48 total; coverage still 100% statements / branches / functions / lines
- `lint`, `typecheck`, `build` clean
- README props table updated for both new props

## Conflict note

The README props-table edit will conflict with #54, which adds a `scriptUrl` row to the same table. Trivial to resolve; happy to rebase whichever lands second.
