### PR TITLE
fix: make the reused-tag timeout configurable, drop the prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,20 +48,21 @@ The component works out of the box in React Server Components environments (e.g.
 
 ## Props
 
-| Prop           | Type                          | Description                                                                                                                                                                            |
-| -------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image`        | `string` (required)           | Image URL or base64 data URL to edit.                                                                                                                                                  |
-| `options`      | `ImageEditorOptions`          | Editor configuration: `projectId`, `user`, `features`, `theme`, `locale`, `translations`, `env`, `offline`, `licenseUrl`, `defaultPrompt`, `autoSubmitPrompt`, `aiAssistantOpenState`. |
-| `editorId`     | `string`                      | id for the container div. Cosmetic — the editor mounts by element reference.                                                                                                           |
-| `minHeight`    | `number \| string`            | Minimum height of the editor container. Defaults to `500`.                                                                                                                             |
-| `style`        | `CSSProperties`               | Styles applied to the container div. Overrides the default `flex: 1`.                                                                                                                  |
-| `wrapperStyle` | `CSSProperties`               | Styles applied to the outer wrapper div, which owns `minHeight` and the flex layout. Set this to drop the editor into a non-flex layout.                                               |
-| `ariaLabel`    | `string`                      | Accessible name for the editor region. Defaults to `'Image editor'`.                                                                                                                   |
-| `onLoad`       | `(editor) => void`            | Called with the editor instance once it is mounted.                                                                                                                                    |
-| `onSave`       | `({ dataUrl, blob }) => void` | Called when the user saves the edited image.                                                                                                                                           |
-| `onCancel`     | `() => void`                  | Called when the user cancels editing.                                                                                                                                                  |
-| `onLoadError`  | `() => void`                  | Called when the image fails to load into the canvas (CORS, 404, decode error).                                                                                                         |
-| `onError`      | `(error: Error) => void`      | Wrapper-level failures: embed script load, editor creation, or image reset. Falls back to `console.error` when absent.                                                                 |
+| Prop                 | Type                          | Description                                                                                                                                                                            |
+| -------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`              | `string` (required)           | Image URL or base64 data URL to edit.                                                                                                                                                  |
+| `options`            | `ImageEditorOptions`          | Editor configuration: `projectId`, `user`, `features`, `theme`, `locale`, `translations`, `env`, `offline`, `licenseUrl`, `defaultPrompt`, `autoSubmitPrompt`, `aiAssistantOpenState`. |
+| `editorId`           | `string`                      | id for the container div. Cosmetic — the editor mounts by element reference.                                                                                                           |
+| `minHeight`          | `number \| string`            | Minimum height of the editor container. Defaults to `500`.                                                                                                                             |
+| `style`              | `CSSProperties`               | Styles applied to the container div. Overrides the default `flex: 1`.                                                                                                                  |
+| `wrapperStyle`       | `CSSProperties`               | Styles applied to the outer wrapper div, which owns `minHeight` and the flex layout. Set this to drop the editor into a non-flex layout.                                               |
+| `ariaLabel`          | `string`                      | Accessible name for the editor region. Defaults to `'Image editor'`.                                                                                                                   |
+| `reusedTagTimeoutMs` | `number`                      | How long to wait (ms) for an embed script tag the host page already placed on the page. Only applies to a reused tag. Defaults to `30000`.                                             |
+| `onLoad`             | `(editor) => void`            | Called with the editor instance once it is mounted.                                                                                                                                    |
+| `onSave`             | `({ dataUrl, blob }) => void` | Called when the user saves the edited image.                                                                                                                                           |
+| `onCancel`           | `() => void`                  | Called when the user cancels editing.                                                                                                                                                  |
+| `onLoadError`        | `() => void`                  | Called when the image fails to load into the canvas (CORS, 404, decode error).                                                                                                         |
+| `onError`            | `(error: Error) => void`      | Wrapper-level failures: embed script load, editor creation, or image reset. Falls back to `console.error` when absent.                                                                 |
 
 ## Editor instance (ref)
 

--- a/src/ImageEditor.tsx
+++ b/src/ImageEditor.tsx
@@ -84,7 +84,9 @@ function ImageEditorInner(
     chainRef.current = chainRef.current
       .then(async () => {
         if (cancelled) return;
-        await loadScript(scriptUrl);
+        // Read at call time from latestPropsRef, so changing the timeout
+        // never tears the editor down and remounts it.
+        await loadScript(scriptUrl, latestPropsRef.current.reusedTagTimeoutMs);
         if (cancelled) return;
 
         const embed = window.ImageEditor;

--- a/src/loadScript.ts
+++ b/src/loadScript.ts
@@ -3,7 +3,7 @@ const defaultScriptUrl = 'https://cdn.unlayer.com/image-editor/embed.js';
 // When reusing a host-injected tag we cannot know whether it already fired
 // `error` (a dead tag never re-fires), so the wait is bounded instead of
 // letting the promise hang forever.
-const REUSED_TAG_TIMEOUT_MS = 30_000;
+export const REUSED_TAG_TIMEOUT_MS = 30_000;
 
 interface TrackedLoad {
   promise: Promise<void>;
@@ -32,12 +32,18 @@ const findScriptTag = (scriptUrl: string): HTMLScriptElement | null => {
  * host-injected tag, if it doesn't become ready within a bounded wait).
  */
 export const loadScript = (
-  scriptUrl: string = defaultScriptUrl
+  scriptUrl: string = defaultScriptUrl,
+  reusedTagTimeoutMs: number = REUSED_TAG_TIMEOUT_MS
 ): Promise<void> => {
   // The embed loader assigns window.ImageEditor synchronously while
   // embed.js evaluates, so its presence means the script already ran
   // (whether we injected it or the host page did).
   if (window.ImageEditor) {
+    // Prefetch the versioned bundle, exactly as the load listener below
+    // does. Without this a page that injected embed.js itself pays a full
+    // extra round trip on the first createEditor. The embed loader caches
+    // its own promise, so a duplicate call is a no-op.
+    window.ImageEditor.load().catch(() => {});
     return Promise.resolve();
   }
 
@@ -99,7 +105,7 @@ export const loadScript = (
             `Timed out waiting for an existing embed script tag: ${scriptUrl}`
           )
         );
-      }, REUSED_TAG_TIMEOUT_MS);
+      }, reusedTagTimeoutMs);
     } else {
       tag.src = scriptUrl;
       document.head.appendChild(tag);

--- a/src/loadScript.ts
+++ b/src/loadScript.ts
@@ -39,11 +39,11 @@ export const loadScript = (
   // embed.js evaluates, so its presence means the script already ran
   // (whether we injected it or the host page did).
   if (window.ImageEditor) {
-    // Prefetch the versioned bundle, exactly as the load listener below
-    // does. Without this a page that injected embed.js itself pays a full
-    // extra round trip on the first createEditor. The embed loader caches
-    // its own promise, so a duplicate call is a no-op.
-    window.ImageEditor.load().catch(() => {});
+    // Deliberately no load() prefetch here. createEditor is awaited
+    // immediately after this resolves and starts the bundle request itself,
+    // so a prefetch would buy a microtask, not a round trip — and calling
+    // load() with no arguments resolves "latest" and caches that promise,
+    // which would defeat any version the embed's own createEditor pins.
     return Promise.resolve();
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,13 @@ export interface ImageEditorProps {
    * globally, so do not mix different scriptUrls across components.
    */
   scriptUrl?: string;
+  /**
+   * How long to wait, in ms, for an embed script tag the host page already
+   * placed on the page to become ready. Only applies when such a tag is
+   * reused — a tag this component injects resolves or errors on its own.
+   * Defaults to 30000. Changing it never remounts the editor.
+   */
+  reusedTagTimeoutMs?: number;
   /** Called with the editor instance once it is mounted. */
   onLoad?(editor: ImageEditorInstance): void;
   /**

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -434,7 +434,37 @@ it('forwards a custom scriptUrl to loadScript', async () => {
   );
   await flush();
 
-  expect(loadScript).toHaveBeenCalledWith('https://example.com/embed.js');
+  expect(loadScript).toHaveBeenCalledWith(
+    'https://example.com/embed.js',
+    undefined
+  );
+});
+
+it('forwards reusedTagTimeoutMs to loadScript', async () => {
+  render(<ImageEditor image="img-a" reusedTagTimeoutMs={5_000} />);
+  await flush();
+
+  expect(loadScript).toHaveBeenCalledWith(undefined, 5_000);
+});
+
+it('leaves loadScript to its own default when the timeout is omitted', async () => {
+  render(<ImageEditor image="img-a" />);
+  await flush();
+
+  expect(loadScript).toHaveBeenCalledWith(undefined, undefined);
+});
+
+it('does not remount when only the timeout changes', async () => {
+  const { rerender } = render(
+    <ImageEditor image="img-a" reusedTagTimeoutMs={5_000} />
+  );
+  await flush();
+
+  rerender(<ImageEditor image="img-a" reusedTagTimeoutMs={9_000} />);
+  await flush();
+
+  expect(mockInstance.destroy).not.toHaveBeenCalled();
+  expect(createEditor).toHaveBeenCalledTimes(1);
 });
 
 it('reports a loadScript failure via onError and recovers on remount', async () => {
@@ -704,7 +734,10 @@ it('remounts when scriptUrl changes', async () => {
 
   expect(mockInstance.destroy).toHaveBeenCalledTimes(1);
   expect(createEditor).toHaveBeenCalledTimes(2);
-  expect(loadScript).toHaveBeenLastCalledWith('https://b.example.com/embed.js');
+  expect(loadScript).toHaveBeenLastCalledWith(
+    'https://b.example.com/embed.js',
+    undefined
+  );
 });
 
 it('reverts theme to default when it is removed from options', async () => {

--- a/test/loadScript.test.ts
+++ b/test/loadScript.test.ts
@@ -192,3 +192,40 @@ it('resetLoader removes the global, the tag, and the cached promise', async () =
   fire(scriptTags()[0], 'load');
   await retry;
 });
+
+it('prefetches the bundle when the host page already installed the global', async () => {
+  // Without this the first createEditor on a host-injected page pays a full
+  // extra round trip that the injected path avoids.
+  const embed = mockEmbed();
+  window.ImageEditor = embed;
+
+  await loadScript();
+
+  expect(embed.load).toHaveBeenCalledTimes(1);
+  expect(scriptTags()).toHaveLength(0);
+});
+
+it('swallows a prefetch failure on the already-installed path', async () => {
+  const embed = mockEmbed();
+  vi.mocked(embed.load).mockRejectedValueOnce(new Error('bundle 404'));
+  window.ImageEditor = embed;
+
+  await expect(loadScript()).resolves.toBeUndefined();
+});
+
+it('accepts a custom reused-tag timeout', async () => {
+  vi.useFakeTimers();
+  try {
+    const hostTag = document.createElement('script');
+    hostTag.src = 'https://cdn.unlayer.com/image-editor/embed.js';
+    document.head.appendChild(hostTag);
+
+    const rejection = expect(
+      loadScript('https://cdn.unlayer.com/image-editor/embed.js', 5_000)
+    ).rejects.toThrow(/Timed out/);
+    vi.advanceTimersByTime(5_000);
+    await rejection;
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/test/loadScript.test.ts
+++ b/test/loadScript.test.ts
@@ -193,24 +193,18 @@ it('resetLoader removes the global, the tag, and the cached promise', async () =
   await retry;
 });
 
-it('prefetches the bundle when the host page already installed the global', async () => {
-  // Without this the first createEditor on a host-injected page pays a full
-  // extra round trip that the injected path avoids.
+it('does not prefetch the bundle when the host page installed the global', async () => {
+  // load() with no arguments resolves "latest" and the embed caches that
+  // promise, so prefetching here would override a version the embed's own
+  // createEditor pins. createEditor is awaited straight after this resolves
+  // and starts the request anyway.
   const embed = mockEmbed();
   window.ImageEditor = embed;
 
   await loadScript();
 
-  expect(embed.load).toHaveBeenCalledTimes(1);
+  expect(embed.load).not.toHaveBeenCalled();
   expect(scriptTags()).toHaveLength(0);
-});
-
-it('swallows a prefetch failure on the already-installed path', async () => {
-  const embed = mockEmbed();
-  vi.mocked(embed.load).mockRejectedValueOnce(new Error('bundle 404'));
-  window.ImageEditor = embed;
-
-  await expect(loadScript()).resolves.toBeUndefined();
 });
 
 it('accepts a custom reused-tag timeout', async () => {


### PR DESCRIPTION
Addresses the `reusedTagTimeoutMs` half of #44. **The prefetch half is dropped** — see below.

## What changed since review

@lucasbesen was right on both counts, and I verified each before acting.

### The prefetch is gone

Two independent reasons:

1. **It didn't eliminate a round trip.** `createEditor` is awaited immediately after `loadScript` resolves and starts the bundle request itself, so the prefetch bought a microtask. Upstream already prefetches on the path where it genuinely helps — inside the `load` listener, where there *is* a gap.
2. **It risked overriding version selection.** `load()` with no arguments resolves `"latest"` and the embed caches that promise, so a version the embed's own `createEditor` pins could be silently ignored on a page that installed `embed.js` itself.

One correction to the review for the record: `MountOptions` has no `version` field in this repo, so `options={{ version: '2.6.0' }}` wouldn't typecheck as written. The *mechanism* is real regardless — a cached `"latest"` promise defeats any pin applied downstream — so the conclusion stands.

A test now pins the no-prefetch behaviour so it can't be reintroduced by accident:

```
✓ does not prefetch the bundle when the host page installed the global
```

I did not try to "demonstrate a meaningful performance improvement" because I don't believe there is one to demonstrate.

### The timeout is now actually reachable

You were right that this didn't address consumer configurability — `loadScript` took the parameter but `ImageEditor` called `loadScript(scriptUrl)` and nothing exposed it.

Adds a `reusedTagTimeoutMs` prop, documented in the README props table. It's read from `latestPropsRef` at call time rather than captured in the effect closure, so **changing it never remounts the editor** — covered by a test.

## Verification

- 51 tests pass; coverage 100% statements / branches / functions / lines
- `lint`, `typecheck`, `build` clean
- Two pre-existing assertions updated for the new two-argument `loadScript` signature

## Note on #44

If this merges as-is, #44 is only half resolved — the prefetch half is being declined rather than implemented. Happy to close #44 with that noted, or leave it open if you'd rather revisit the host-injected path separately.
