### PR TITLE
test: cover the SSR and "use client" guarantees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@testing-library/react": "16.3.2",
+        "@types/node": "24.10.9",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitest/coverage-v8": "4.1.10",
@@ -2025,6 +2026,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -4853,6 +4864,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@testing-library/react": "16.3.2",
+    "@types/node": "24.10.9",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "4.1.10",

--- a/test/ssr.test.tsx
+++ b/test/ssr.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment node
+//
+// The rest of the suite runs in jsdom, so nothing here verified the
+// README's claim that the component "works out of the box in React Server
+// Components environments ... and touches the DOM only inside effects".
+// This file runs with no DOM at all.
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { renderToString } from 'react-dom/server';
+
+import ImageEditor from '../src';
+
+it('has no DOM in this environment', () => {
+  // Guards the guard: if jsdom leaked in, the test below proves nothing.
+  expect(typeof document).toBe('undefined');
+  expect(typeof window).toBe('undefined');
+});
+
+it('renders to a string on the server without touching the DOM', () => {
+  const html = renderToString(
+    <ImageEditor image="https://example.com/photo.jpg" editorId="ssr" />
+  );
+
+  expect(html).toContain('id="ssr"');
+});
+
+it('renders on the server with every prop set', () => {
+  // Effects never run on the server, so a prop that reaches the DOM during
+  // render rather than in an effect would throw here.
+  expect(() =>
+    renderToString(
+      <ImageEditor
+        image="https://example.com/photo.jpg"
+        options={{ theme: 'dark', locale: 'fr', projectId: 1234 }}
+        scriptUrl="https://cdn.example.com/embed.js"
+        minHeight="80vh"
+        style={{ borderRadius: 8 }}
+        onLoad={() => {}}
+        onSave={() => {}}
+        onCancel={() => {}}
+        onLoadError={() => {}}
+        onError={() => {}}
+      />
+    )
+  ).not.toThrow();
+});
+
+// The 'use client' banner comes from tsup config, which nothing else
+// checks — a bundler or config change could silently drop it and every
+// existing test would still pass. Runs after `npm run build`; skipped in
+// the React/Node matrix jobs, which do not build.
+const dist = (file: string) => resolve(__dirname, '..', 'dist', file);
+const built = existsSync(dist('index.mjs'));
+
+it.skipIf(!built)('ships the "use client" directive in both builds', () => {
+  for (const file of ['index.js', 'index.mjs']) {
+    expect(readFileSync(dist(file), 'utf8').startsWith("'use client';")).toBe(
+      true
+    );
+  }
+});

--- a/test/ssr.test.tsx
+++ b/test/ssr.test.tsx
@@ -48,8 +48,9 @@ it('renders on the server with every prop set', () => {
 
 // The 'use client' banner comes from tsup config, which nothing else
 // checks — a bundler or config change could silently drop it and every
-// existing test would still pass. Runs after `npm run build`; skipped in
-// the React/Node matrix jobs, which do not build.
+// existing test would still pass. dist/ exists in every CI job, because
+// `npm ci` runs the `prepare` script and that builds; the skip is only for
+// a local run before anyone has built.
 const dist = (file: string) => resolve(__dirname, '..', 'dist', file);
 const built = existsSync(dist('index.mjs'));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   }
 }


### PR DESCRIPTION
Fixes #41.

The README makes two promises that nothing verified:

> works out of the box in React Server Components environments (e.g. Next.js App Router) — it ships with the `'use client'` directive and touches the DOM only inside effects

The whole suite runs in `jsdom`, so every test renders client-side, and the `'use client'` banner is a `tsup` config detail — a bundler or config change could drop it and every existing test would still pass.

## New `test/ssr.test.tsx`, running with `@vitest-environment node`

1. **Asserts there is genuinely no DOM** in that environment first — otherwise, if jsdom leaked in, the rest of the file would prove nothing.
2. **`renderToString`** the component, bare and again with every prop set. Effects don't run on the server, so a prop that reached the DOM during render rather than in an effect would throw here.
3. **Asserts both built bundles start with `'use client';`**.

## Verification

The banner assertion is not decorative — I deleted the `banner` line from `tsup.config.ts`, rebuilt, and it failed:

```
× ships the "use client" directive in both builds
```

It also skips cleanly rather than failing when `dist/` is absent:

```
Tests  3 passed | 1 skipped (4)
```

That matters because the `checks` CI job runs `npm run build` before the tests (so it executes there), while the Node/React matrix jobs run `npm test` without building (so it skips).

- 4 new tests; 50 total; coverage still 100% across the board
- `lint`, `typecheck` clean
