### PR TITLE
feat: add a placeholder slot for the embed loading gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The component works out of the box in React Server Components environments (e.g.
 | `style`        | `CSSProperties`               | Styles applied to the container div. Overrides the default `flex: 1`.                                                                                                                  |
 | `wrapperStyle` | `CSSProperties`               | Styles applied to the outer wrapper div, which owns `minHeight` and the flex layout. Set this to drop the editor into a non-flex layout.                                               |
 | `ariaLabel`    | `string`                      | Accessible name for the editor region. Defaults to `'Image editor'`.                                                                                                                   |
+| `placeholder`  | `ReactNode`                   | Rendered centred over the container until the editor mounts — a spinner or skeleton for the embed's cold-cache load. Stays visible if the mount fails.                                 |
 | `onLoad`       | `(editor) => void`            | Called with the editor instance once it is mounted.                                                                                                                                    |
 | `onSave`       | `({ dataUrl, blob }) => void` | Called when the user saves the edited image.                                                                                                                                           |
 | `onCancel`     | `() => void`                  | Called when the user cancels editing.                                                                                                                                                  |
@@ -87,6 +88,16 @@ const dataUrl = editorRef.current?.editor?.getImage();
 | `options.theme`, `options.locale`, `options.translations`    | Applied via `updateOptions()` — no remount, editor state preserved.                                                                      |
 | Any other `options` key                                      | Full remount — the editor is destroyed and recreated with the new configuration.                                                         |
 | `onSave` / `onCancel` / `onLoadError` / `onLoad` / `onError` | Always call the latest handler; changing them never remounts.                                                                            |
+
+## Loading state
+
+The embed script and its versioned bundle are fetched at mount. On a cold cache that is a visible gap, so pass a `placeholder` to fill it:
+
+```jsx
+<ImageEditor image={url} placeholder={<Spinner />} />
+```
+
+It is rendered centred over the container and removed once the editor is live. It is **not** removed when the mount fails, so a failed load never leaves a blank box — pair it with `onError` to swap in a failure message.
 
 ## Error handling
 

--- a/src/ImageEditor.tsx
+++ b/src/ImageEditor.tsx
@@ -21,6 +21,7 @@ function ImageEditorInner(
     style = {},
     wrapperStyle = {},
     ariaLabel = 'Image editor',
+    placeholder,
   } = props;
 
   const [editor, setEditor] = useState<ImageEditorInstance | null>(null);
@@ -202,12 +203,20 @@ function ImageEditorInner(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, updatableKey]);
 
+  // Rendered as an overlay sibling rather than a child of the mount
+  // container: the embed owns that container's DOM, and React must not
+  // reconcile children in and out from under it.
+  const showPlaceholder = placeholder !== undefined && editor === null;
+
   return (
     <div
       style={{
         flex: 1,
         display: 'flex',
         minHeight: minHeight,
+        // Only when needed, so existing layouts are untouched.
+        ...(showPlaceholder ? { position: 'relative' } : null),
+        // Last, so a consumer can still override position if they need to.
         ...wrapperStyle,
       }}
     >
@@ -222,6 +231,19 @@ function ImageEditorInner(
         // flex first: a default the consumer's style can override.
         style={{ flex: 1, ...style }}
       />
+      {showPlaceholder && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {placeholder}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 
 import type {
   Features,
@@ -113,6 +113,13 @@ export interface ImageEditorProps {
    * and no name of its own. Defaults to 'Image editor'.
    */
   ariaLabel?: string;
+  /**
+   * Rendered centred over the container until the editor is mounted — a
+   * spinner or skeleton for the embed's cold-cache load. Stays visible if
+   * the mount fails, so a blank box is never the end state; pair it with
+   * `onError` to swap in a failure message.
+   */
+  placeholder?: ReactNode;
   /**
    * Override the embed script URL (e.g. to pin an environment). One embed
    * per page: the first loader to run installs window.ImageEditor and wins

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -400,6 +400,73 @@ it('gives the editor region an accessible name, overridable via ariaLabel', asyn
   expect(container.getAttribute('aria-label')).toBe('Avatar cropper');
 });
 
+it('shows the placeholder until the editor mounts, then removes it', async () => {
+  const created = defer<ImageEditorInstance>();
+  createEditor.mockReturnValueOnce(created.promise);
+
+  render(<ImageEditor image="img-a" placeholder={<p>Loading…</p>} />);
+
+  // Visible for the whole embed load + createEditor round trip.
+  expect(document.body.textContent).toContain('Loading…');
+
+  await act(async () => {
+    created.resolve(mockInstance as unknown as ImageEditorInstance);
+  });
+
+  expect(document.body.textContent).not.toContain('Loading…');
+});
+
+it('renders no placeholder element when the prop is absent', async () => {
+  const { container } = render(<ImageEditor image="img-a" />);
+  await flush();
+
+  const wrapper = container.firstElementChild as HTMLElement;
+  // Just the mount container — no overlay, and no positioning added.
+  expect(wrapper.children).toHaveLength(1);
+  expect(wrapper.style.position).toBe('');
+});
+
+it('keeps the placeholder visible when the mount fails', async () => {
+  createEditor.mockRejectedValueOnce(new Error('bundle 404'));
+
+  render(
+    <ImageEditor
+      image="img-a"
+      placeholder={<p>Loading…</p>}
+      onError={vi.fn()}
+    />
+  );
+  await flush();
+
+  // A failed mount must not leave a blank box behind.
+  expect(document.body.textContent).toContain('Loading…');
+});
+
+it('brings the placeholder back while a remount is in flight', async () => {
+  const { rerender } = render(
+    <ImageEditor image="img-a" placeholder={<p>Loading…</p>} />
+  );
+  await flush();
+  expect(document.body.textContent).not.toContain('Loading…');
+
+  const second = defer<ImageEditorInstance>();
+  createEditor.mockReturnValueOnce(second.promise);
+  rerender(
+    <ImageEditor
+      image="img-a"
+      placeholder={<p>Loading…</p>}
+      options={{ projectId: 1 }}
+    />
+  );
+
+  expect(document.body.textContent).toContain('Loading…');
+
+  await act(async () => {
+    second.resolve(makeInstance() as unknown as ImageEditorInstance);
+  });
+  expect(document.body.textContent).not.toContain('Loading…');
+});
+
 it('passes onCancel and onLoadError through to the editor', async () => {
   const onCancel = vi.fn();
   const onLoadError = vi.fn();


### PR DESCRIPTION
Fixes #37.

## Problem

Between mount and the editor being ready, the component rendered an empty container. On a cold CDN cache that's the full `embed.js` request **plus** the versioned-bundle hop showing as a blank box at `minHeight: 500`.

There was no supported way to fill it: `onLoad` only fires *after* success, so consumers had to render their own absolutely-positioned overlay from first paint, tear it down in `onLoad`, know about the internal two-div layout — and it still didn't cover the failure path.

## Change

```jsx
<ImageEditor image={url} placeholder={<Spinner />} />
```

Two design decisions worth your attention:

- **It's an overlay sibling, not a child of the mount container.** The embed owns that container's DOM (it renders `div.image-editor-root` into it), so React must not reconcile children in and out from under it.
- **It stays visible when the mount fails.** The issue flagged this as an open question. A failed load ending on a blank box is the worst outcome, so the placeholder persists and consumers pair it with `onError` to swap in a failure message. Documented in the README and the prop's doc comment.

`position: relative` is applied to the wrapper **only while a placeholder is actually showing**, so existing layouts are untouched.

## Verification

Beyond the unit tests, I wired it into the demo and pointed `scriptUrl` at a non-existent file to hold the failure state open.

**Before** — embed fails to load, entire editor area is blank white:

> status bar reads `Error: Failed to load the image editor embed script: .../DOES-NOT-EXIST.js`, content area completely empty

**After** — same failure, with a spinner and "Loading the image editor…" centred in the area.

The demo scaffolding was reverted; this PR touches only `src/`, `test/` and the README.

- 4 new tests (shown until mount, absent when the prop is, survives a failed mount, returns during a remount)
- 50 tests; coverage still 100% statements / branches / functions / lines
- `lint`, `typecheck`, `build` clean

## Conflict note

Touches the same render block as #55, and the same README props table as #54.
