### PR TITLE
ci: publish releases from CI, with a changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+      id-token: write # required for npm provenance
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # release notes need history
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      # prepublishOnly runs these too, but running them here fails the job
+      # before anything is published rather than midway through.
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build
+
+      # A tag that disagrees with package.json would publish the wrong
+      # version under the right tag name, which cannot be undone.
+      - name: Verify the tag matches package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::tag v$tag does not match package.json version $pkg"
+            exit 1
+          fi
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+
+- Support the image editor `dock` and `corners` options in `Features` ([#25](https://github.com/unlayer/react-image-editor/issues/25))
+
+### Changed
+
+- Use the modern JSX transform
+
+### Internal
+
+- Full (100%) test coverage and additional edge-case scenarios
+
+## 1.0.2
+
+### Fixed
+
+- Contain exceptions thrown by a consumer's `onLoad` callback, so they can no longer surface as a wrapper failure ([#22](https://github.com/unlayer/react-image-editor/pull/22))
+
+### Added
+
+- Demo: image upload, so the demo can be tried with your own images
+
+## 1.0.1
+
+### Fixed
+
+- Contain exceptions thrown by a consumer's `onError` callback, which previously escaped as an unhandled promise rejection ([#9](https://github.com/unlayer/react-image-editor/issues/9))
+- Demo: auto-install demo dependencies in the root `dev` script, so a fresh clone works without a second `npm install` ([#8](https://github.com/unlayer/react-image-editor/issues/8))
+
+### Added
+
+- Demo: dark chrome for the top bar and sidebar
+
+## 1.0.0
+
+Initial release: the Unlayer Image Editor as a React component.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,19 @@
 - `npm run build` builds the component for publishing to npm.
 - `npm run build` in the `demo` directory builds the demo app.
 
+## Releasing
+
+Releases are published from CI, not from a maintainer's machine.
+
+1. Update `CHANGELOG.md`: rename `Unreleased` to the new version.
+2. Bump the version: `npm version <patch|minor|major>` (this creates the `vX.Y.Z` tag).
+3. `git push --follow-tags`.
+
+Pushing the tag runs `.github/workflows/release.yml`, which re-runs lint,
+typecheck, tests and build, verifies the tag matches `package.json`, publishes
+to npm with [provenance](https://docs.npmjs.com/generating-provenance-statements),
+and creates the GitHub Release. It needs an `NPM_TOKEN` repository secret.
+
 ## Conventions
 
 - Commit messages follow [Conventional Commits 1.0](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
Fixes #35.

Publishing was a manual `npm run build && npm publish` from a maintainer's machine. `prepublishOnly` did run the checks, which is good — everything around the publish was missing:

- **no git tags** (`git tag` returns nothing — no `v1.0.0`/`v1.0.1`/`v1.0.2`)
- **no GitHub Releases**, which follows from that
- **no `CHANGELOG.md`** — the only record across three published versions is the pair of `chore(release):` commits
- **no npm provenance**

## `.github/workflows/release.yml`

Triggered on a `v*` tag (plus `workflow_dispatch`). Re-runs lint / typecheck / test / build, publishes with `--provenance`, and creates the GitHub Release with generated notes.

Three details worth calling out:

- **Tag/version guard.** Before publishing, it checks `$GITHUB_REF_NAME` matches `package.json`. Publishing 1.0.2's contents under a `v1.0.3` tag is unfixable on npm, so it's worth the five lines. Verified both branches locally:
  ```
  v1.0.2 -> accepted
  v9.9.9 -> REJECTED (pkg 1.0.2)
  ```
- **Least privilege.** Top-level `permissions: contents: read`; the job adds `contents: write` (the Release) and `id-token: write` (provenance requires OIDC).
- Checks run in the job as well as via `prepublishOnly` so the job fails *before* anything is published rather than midway through.

## `CHANGELOG.md`

Backfilled for 1.0.0–1.0.2 by reading the git history between the release commits, with issue/PR links where I could identify them. Please sanity-check the 1.0.0 entry — there's no history boundary marking it, so it's a placeholder.

Also added a **Releasing** section to CONTRIBUTING with the tag-and-push flow.

## What I could not verify

**I have not run this workflow.** I validated the YAML parses and exercised the tag-guard shell logic locally, but the publish path can only be proven by a real release. It also needs an **`NPM_TOKEN` repository secret** that doesn't exist yet — worth adding before the first tag, and worth a granular token scoped to this package.

Suggested first use: cut `v1.0.3` from `Unreleased`, or backfill tags at the historical release commits (`abed34d` = 1.0.1, `459e0ad` = 1.0.2) first if you want the Releases page to read completely.
