### PR TITLE
test: trip when the mirrored editor types move upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@testing-library/react": "16.3.2",
+        "@types/node": "24.10.9",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitest/coverage-v8": "4.1.10",
@@ -2025,6 +2026,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -4853,6 +4864,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@testing-library/react": "16.3.2",
+    "@types/node": "24.10.9",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "4.1.10",

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,11 @@ export interface ImageEditorSaveResult {
 // KEEP IN SYNC WITH packages/image-editor/src/index.ts in the unlayer
 // monorepo — these mirror the private @unlayer/image-editor package's
 // public API until they move into @unlayer/types.
+//
+// test/typesDrift.test.ts enforces the "until": it fails as soon as
+// @unlayer/types exports any of these names, so the local copy gets deleted
+// rather than left to diverge. It cannot detect the private package
+// changing underneath us — that still needs a human.
 
 /**
  * Options for mounting the image editor.

--- a/test/typesDrift.test.ts
+++ b/test/typesDrift.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// src/types.ts hand-mirrors the private @unlayer/image-editor public API,
+// with a comment saying it does so "until they move into @unlayer/types".
+// Nothing enforced the "until": once the move happens, the local copies
+// silently become a second, diverging source of truth — which is how #25
+// (a missing `dock`/`corners`) reached users.
+//
+// This is a tripwire, not a full drift check: a real one needs access to the
+// private package. It fails the moment @unlayer/types starts exporting any
+// mirrored name, so the local copy gets deleted rather than left to rot.
+const MIRRORED = [
+  'MountOptions',
+  'ImageEditorInstance',
+  'ImageEditorEmbed',
+  'ImageEditorSaveResult',
+];
+
+const collectDeclarations = (dir: string): string => {
+  let out = '';
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out += collectDeclarations(path);
+    else if (entry.name.endsWith('.d.ts')) out += readFileSync(path, 'utf8');
+  }
+  return out;
+};
+
+it('still needs its local copy of the image editor types', () => {
+  // Read the package directory directly: @unlayer/types restricts its
+  // "exports" field, so require.resolve cannot reach its package.json.
+  const declarations = collectDeclarations(
+    join(process.cwd(), 'node_modules', '@unlayer', 'types')
+  );
+
+  const moved = MIRRORED.filter((name) =>
+    new RegExp(`\\b(interface|type)\\s+${name}\\b`).test(declarations)
+  );
+
+  expect(
+    moved,
+    moved.length
+      ? `@unlayer/types now exports ${moved.join(', ')}. Delete the mirrored ` +
+          `declaration(s) from src/types.ts and re-export from @unlayer/types ` +
+          `instead, then drop the name(s) from this test.`
+      : ''
+  ).toEqual([]);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   }
 }


### PR DESCRIPTION
Partially addresses #42 — please read the caveat before merging.

## What this does

`src/types.ts` hand-copies `MountOptions`, `ImageEditorInstance`, `ImageEditorEmbed` and `ImageEditorSaveResult` from the private `@unlayer/image-editor` package, with a comment saying it does so *"until they move into `@unlayer/types`"*. Nothing enforced the "until".

Once that move happens, the local copies silently become a second, diverging source of truth. That's exactly how #25 (`Features.imageEditor` missing `dock`/`corners`) reached users.

`test/typesDrift.test.ts` scans the installed `@unlayer/types` declarations and fails the moment any mirrored name appears there:

```
AssertionError: @unlayer/types now exports JSONTemplate. Delete the mirrored
declaration(s) from src/types.ts and re-export from @unlayer/types instead,
then drop the name(s) from this test.
```

(That output is from deliberately adding a name that *does* exist upstream, to prove the tripwire fires — it passes as-is today, since `@unlayer/types@1.477.0` exports none of the four.)

The `KEEP IN SYNC` comment now points at the test, so the enforcement is discoverable from the declarations.

## What this deliberately does NOT do

**It does not detect the private `@unlayer/image-editor` package changing underneath you** — the more dangerous direction, where a renamed instance method typechecks fine and throws at runtime.

Of the three options in the issue:

1. **Move the types into `@unlayer/types`** — the durable fix, and the comment's own stated intent. Only Unlayer can publish that.
2. **CI drift check against the private package** — needs access this repository doesn't have.
3. **Runtime shape assertion** — I chose not to add one. It would mean loading the live CDN embed in CI, which makes the suite network-dependent and flaky for a check that only fires on a rename.

So this closes the cheap half and leaves the real fix as yours. Happy to do the `@unlayer/types` migration in a follow-up if you publish the types there.

Tests 47, coverage still 100%; `lint`, `typecheck`, `build` clean.
