### PR TITLE
feat(demo): exercise AI Assistant, corners and custom tool icons

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,0 +1,4 @@
+# Optional. A projectId from https://console.unlayer.com/ with the AI
+# Assistant feature enabled. The demo hides the AI controls when this is
+# unset, so the rest of the demo works without an account.
+VITE_UNLAYER_PROJECT_ID=

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -20,6 +20,15 @@ const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
 // overlay. Starting it open at these widths hides the editor behind it.
 const WIDE_VIEWPORT = '(min-width: 768px)';
 
+// The AI Assistant needs a projectId with the feature enabled, so the demo
+// only offers it when one is configured. See demo/.env.example.
+const PROJECT_ID = Number(import.meta.env.VITE_UNLAYER_PROJECT_ID) || undefined;
+
+// Demonstrates features.imageEditor.tools.<tool>.icon. Raw <svg> markup is
+// the form that works today; see #64 for the Font Awesome name form.
+const CUSTOM_TEXT_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7V5h16v2M12 5v14M9 19h6" /></svg>';
+
 const allToolsEnabled = () =>
   Object.fromEntries(TOOL_NAMES.map((tool) => [tool, true])) as Record<
     ToolName,
@@ -38,6 +47,7 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(
     () => window.matchMedia(WIDE_VIEWPORT).matches
   );
+  const [ai, setAi] = useState(false);
   const [saved, setSaved] = useState<ImageEditorSaveResult | null>(null);
   const [status, setStatus] = useState('Loading editor…');
 
@@ -94,12 +104,14 @@ export default function App() {
     setStatus(editor.hasChanges() ? 'Unsaved changes' : 'No unsaved changes');
   };
 
-  const snapshot = () => {
+  const snapshot = async () => {
     const dataUrl = editorRef.current?.editor?.getImage();
-    if (dataUrl) {
-      setSaved({ dataUrl, blob: new Blob() });
-      setStatus('Snapshot taken via getImage()');
-    }
+    if (!dataUrl) return;
+    // Build the real blob rather than an empty one: this object is shaped
+    // like an ImageEditorSaveResult, so it should not lie about `blob`.
+    const blob = await (await fetch(dataUrl)).blob();
+    setSaved({ dataUrl, blob });
+    setStatus(`Snapshot taken via getImage() (${blob.size} bytes)`);
   };
 
   const changeDock = (next: 'left' | 'right') => {
@@ -147,6 +159,14 @@ export default function App() {
             onDockChange={changeDock}
             tools={tools}
             onToolToggle={toggleTool}
+            aiAvailable={PROJECT_ID !== undefined}
+            ai={ai}
+            onAiChange={(enabled) => {
+              setAi(enabled);
+              setStatus(
+                `AI Assistant ${enabled ? 'enabled' : 'disabled'} (remount)`
+              );
+            }}
             onChangeImage={nextImage}
             onUploadImage={uploadImage}
             onCheckChanges={checkChanges}
@@ -161,7 +181,24 @@ export default function App() {
             options={{
               theme,
               locale,
-              features: { imageEditor: { dock, tools } },
+              projectId: PROJECT_ID,
+              features: {
+                ai: { enabled: ai, assistant: ai },
+                imageEditor: {
+                  dock,
+                  tools: {
+                    ...tools,
+                    // A tool entry can also be an object, which is how a
+                    // custom icon is supplied. Raw <svg> markup, not a Font
+                    // Awesome name — the name form is silently ignored
+                    // (see #64).
+                    text: {
+                      enabled: tools.text,
+                      icon: CUSTOM_TEXT_ICON,
+                    },
+                  },
+                },
+              },
             }}
             onLoad={() => setStatus('Editor ready')}
             onSave={(result) => {

--- a/demo/src/Sidebar.tsx
+++ b/demo/src/Sidebar.tsx
@@ -4,6 +4,9 @@ import type { UnlayerLocale } from '@unlayer/types';
 
 export const TOOL_NAMES = [
   'crop',
+  // Configured through features.imageEditor.tools like any other tool, but
+  // it is the rounded-corners control inside Crop rather than its own tab.
+  'corners',
   'resize',
   'filter',
   'draw',
@@ -30,6 +33,9 @@ interface SidebarProps {
   onLocaleChange(locale: UnlayerLocale): void;
   dock: 'left' | 'right';
   onDockChange(dock: 'left' | 'right'): void;
+  aiAvailable: boolean;
+  ai: boolean;
+  onAiChange(enabled: boolean): void;
   tools: Record<ToolName, boolean>;
   onToolToggle(tool: ToolName): void;
   onChangeImage(): void;
@@ -111,6 +117,25 @@ export default function Sidebar(props: SidebarProps) {
             <option value="right">Right</option>
           </select>
         </label>
+      </section>
+
+      <section className="section">
+        <h2 className="section-label">AI Assistant</h2>
+        {props.aiAvailable ? (
+          <label className="tool-toggle">
+            <input
+              type="checkbox"
+              checked={props.ai}
+              onChange={(event) => props.onAiChange(event.target.checked)}
+            />
+            Enable AI Assistant
+          </label>
+        ) : (
+          <p className="hint">
+            Set <code>VITE_UNLAYER_PROJECT_ID</code> in <code>demo/.env</code>{' '}
+            to try the AI Assistant. See <code>demo/.env.example</code>.
+          </p>
+        )}
       </section>
 
       <section className="section">

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -297,3 +297,17 @@ body,
     font-size: 14px;
   }
 }
+
+.hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #8f96a3;
+}
+
+.hint code {
+  font-size: 11px;
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: #232732;
+}

--- a/demo/src/vite-env.d.ts
+++ b/demo/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Optional Unlayer projectId; enables the AI Assistant controls. */
+  readonly VITE_UNLAYER_PROJECT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Fixes #40.

The demo is the main thing people try before adopting the component, but several documented options were never wired into it — including the AI Assistant, the README's headline feature.

### Added

| Option | How |
| --- | --- |
| `projectId` + `features.ai` | AI Assistant toggle, gated on `VITE_UNLAYER_PROJECT_ID`. When unset, the controls are replaced by a pointer to the new `demo/.env.example`, so the demo still works with no Unlayer account. |
| `features.imageEditor.dock` | Left/Right tool-rail selector. |
| `tools.corners` | Was missing from `TOOL_NAMES` entirely. |
| custom tool icon | Raw `<svg>` markup on the Text tool. |

### Fixed: the snapshot lied about its blob

```js
setSaved({ dataUrl, blob: new Blob() });   // 0 bytes
```

The Download link worked (it uses `dataUrl`), but the object claimed to be an `ImageEditorSaveResult` while fabricating `blob` — misleading in the file people read to learn the API. It now builds the real blob:

```
Snapshot taken via getImage() (1998122 bytes)
```

## ⚠️ A bug I found doing this — #64

**The README's own Font Awesome icon example does not work.** I started with `icon: 'fa-font'`, saw no change, and checked properly against the live embed:

| `icon` value | result |
| --- | --- |
| `'fa-crop-simple'` (the README's example) | ❌ silently ignored, default icon stays |
| `'fa-star'` | ❌ silently ignored |
| raw `'<svg …>'` | ✅ works |

Filed as #64. **This PR uses the raw-`<svg>` form**, so the demo ships an example that actually does something rather than one that silently no-ops.

## Verification

Driven against the live CDN embed at 1280×800:

- new sidebar sections present: `Layout (remounts editor)`, `AI Assistant`
- `corners` present in the tool toggles
- dock switch moves the rail: `left: 968` → `left: 0` in a 1040px editor
- custom SVG icon rendered in the rail
- snapshot produces a real 1,998,122-byte blob
- AI hint shown (no `projectId` configured in my environment)

`tsc --noEmit`, `vite build`, root tests and Prettier all clean.

## Left out deliberately

`translations`, `offline`/`licenseUrl`/`env` and `scriptUrl`. Each needs real scaffolding (a translations fixture, a license file, an alternate CDN) that would make this PR much harder to review, and none is as load-bearing as the AI Assistant gap. Happy to follow up.

## Conflict note

Touches `demo/src/App.tsx`, `Sidebar.tsx` and `styles.css`, so it will conflict with #59 (demo responsive/theme).
